### PR TITLE
Fix critical chmod regression, quoting, and timestamp format

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,11 +2,11 @@
 set -eu
 
 execute_ssh(){
-  echo "Execute Over SSH: $@"
-  ssh -q -t -i "$HOME/.ssh/id_rsa" \
+  echo "Execute Over SSH: $*"
+  ssh -q -i "$HOME/.ssh/id_rsa" \
       -o UserKnownHostsFile=/dev/null \
-      -p $INPUT_REMOTE_DOCKER_PORT \
-      -o StrictHostKeyChecking=no "$INPUT_REMOTE_DOCKER_HOST" "$@"
+      -p "$INPUT_REMOTE_DOCKER_PORT" \
+      -o StrictHostKeyChecking=no "$INPUT_REMOTE_DOCKER_HOST" "$*"
 }
 
 if [ -z "${INPUT_REMOTE_DOCKER_PORT+x}" ]; then
@@ -89,13 +89,13 @@ printf '%s\n' "$INPUT_SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa
 printf '%s\n' "$INPUT_SSH_PUBLIC_KEY" > ~/.ssh/id_rsa.pub
 chmod 600 ~/.ssh/id_rsa.pub
-chmod 600 ~/.ssh
+chmod 700 ~/.ssh
 eval $(ssh-agent)
 ssh-add ~/.ssh/id_rsa
 
 echo "Add known hosts"
-ssh-keyscan -p $INPUT_REMOTE_DOCKER_PORT "$SSH_HOST" >> ~/.ssh/known_hosts
-ssh-keyscan -p $INPUT_REMOTE_DOCKER_PORT "$SSH_HOST" >> /etc/ssh/ssh_known_hosts
+ssh-keyscan -p "$INPUT_REMOTE_DOCKER_PORT" "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+ssh-keyscan -p "$INPUT_REMOTE_DOCKER_PORT" "$SSH_HOST" >> /etc/ssh/ssh_known_hosts 2>/dev/null || true
 
 # set context  # This command was causing issues and is commented out
 echo "Create docker context"
@@ -107,28 +107,28 @@ if ! [ -z "${INPUT_DOCKER_REGISTRY_USERNAME+x}" ] && ! [ -z "${INPUT_DOCKER_REGI
   echo "$INPUT_DOCKER_REGISTRY_PASSWORD" | docker login -u "$INPUT_DOCKER_REGISTRY_USERNAME" --password-stdin "$INPUT_DOCKER_REGISTRY_URI"
 fi
 
-if ! [ -z "${INPUT_DOCKER_PRUNE+x}" ] && [ $INPUT_DOCKER_PRUNE = 'true' ] ; then
+if ! [ -z "${INPUT_DOCKER_PRUNE+x}" ] && [ "$INPUT_DOCKER_PRUNE" = 'true' ] ; then
   yes | docker --log-level debug --host "ssh://$INPUT_REMOTE_DOCKER_HOST:$INPUT_REMOTE_DOCKER_PORT" system prune -a 2>&1
 fi
 
-if ! [ -z "${INPUT_COPY_STACK_FILE+x}" ] && [ $INPUT_COPY_STACK_FILE = 'true' ] ; then
+if ! [ -z "${INPUT_COPY_STACK_FILE+x}" ] && [ "$INPUT_COPY_STACK_FILE" = 'true' ] ; then
   execute_ssh "mkdir -p $INPUT_DEPLOY_PATH/stacks || true"
-  FILE_NAME="docker-stack-$(date +%Y%m%d%s).yaml"
+  FILE_NAME="docker-stack-$(date +%Y%m%d%H%M%S).yaml"
 
   scp -i "$HOME/.ssh/id_rsa" \
       -o UserKnownHostsFile=/dev/null \
       -o StrictHostKeyChecking=no \
-      -P $INPUT_REMOTE_DOCKER_PORT \
-      $INPUT_STACK_FILE_NAME "$INPUT_REMOTE_DOCKER_HOST:$INPUT_DEPLOY_PATH/stacks/$FILE_NAME"
+      -P "$INPUT_REMOTE_DOCKER_PORT" \
+      "$INPUT_STACK_FILE_NAME" "$INPUT_REMOTE_DOCKER_HOST:$INPUT_DEPLOY_PATH/stacks/$FILE_NAME"
 
   execute_ssh "ln -nfs $INPUT_DEPLOY_PATH/stacks/$FILE_NAME $INPUT_DEPLOY_PATH/$INPUT_STACK_FILE_NAME"
-  execute_ssh "ls -t $INPUT_DEPLOY_PATH/stacks/docker-stack-* 2>/dev/null |  tail -n +$INPUT_KEEP_FILES | xargs rm --  2>/dev/null || true"
+  execute_ssh "ls -t $INPUT_DEPLOY_PATH/stacks/docker-stack-* 2>/dev/null | tail -n +$INPUT_KEEP_FILES | xargs rm --  2>/dev/null || true"
 
-  if ! [ -z "${INPUT_PULL_IMAGES_FIRST+x}" ] && [ $INPUT_PULL_IMAGES_FIRST = 'true' ] && [ $INPUT_DEPLOYMENT_MODE = 'docker-compose' ] ; then
+  if ! [ -z "${INPUT_PULL_IMAGES_FIRST+x}" ] && [ "$INPUT_PULL_IMAGES_FIRST" = 'true' ] && [ "$INPUT_DEPLOYMENT_MODE" = 'docker-compose' ] ; then
     execute_ssh "${DEPLOYMENT_COMMAND}" "pull"
   fi
 
-  if ! [ -z "${INPUT_PRE_DEPLOYMENT_COMMAND_ARGS+x}" ] && [ $INPUT_DEPLOYMENT_MODE = 'docker-compose' ] ; then
+  if ! [ -z "${INPUT_PRE_DEPLOYMENT_COMMAND_ARGS+x}" ] && [ "$INPUT_DEPLOYMENT_MODE" = 'docker-compose' ] ; then
     execute_ssh "${DEPLOYMENT_COMMAND}  $INPUT_PRE_DEPLOYMENT_COMMAND_ARGS" 2>&1
   fi
 
@@ -137,5 +137,3 @@ else
   echo "Connecting to $INPUT_REMOTE_DOCKER_HOST... Command: ${DEPLOYMENT_COMMAND} ${INPUT_ARGS}"
   "${DEPLOYMENT_COMMAND}" "${INPUT_ARGS}" 2>&1
 fi
-
-


### PR DESCRIPTION
Round 7 of review. Found several issues after R6:

## Critical
- **chmod 600 on ~/.ssh directory** — R6 added this but 600 on a directory removes the execute bit, making it completely inaccessible. SSH operations fail immediately (can't cd into dir, can't read keys). Fixed to 700.

## Bugs
- **-t flag on SSH** — forces TTY allocation which fails in CI/automation contexts where no TTY exists
- **Unquoted port variables** — $INPUT_REMOTE_DOCKER_PORT unquoted in ssh -p, scp -P, and ssh-keyscan -p (word splitting risk)
- **`date +%Y%m%d%s`** — `%s` is epoch seconds, so two deploys within the same second get identical filenames. Changed to %H%M%S for human-readable unique timestamps
- **$@ vs $*** in execute_ssh — $@ creates separate args which break when DEPLOYMENT_COMMAND is a multi-word string passed to SSH
- **Unquoted comparisons** — `[ $var = 'true' ]` without quoting $var causes errors if var is empty/unset
- **ssh-keyscan stderr noise** — floods logs with connection details
- **Unquoted $INPUT_STACK_FILE_NAME** in scp — breaks on filenames with spaces