### PR TITLE
fix: compose upgrade, TTY removal, pipefail, quoting & cleanup hardening

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM docker/compose:1.29.2
+FROM docker/compose:2.24.5
+
+RUN apk --no-cache add openssh-client
+
+# Install docker-compose v2 CLI plugin support
+RUN mkdir -p /usr/local/lib/docker/cli-plugins && \
+    ln -s /usr/local/bin/docker-compose /usr/local/lib/docker/cli-plugins/docker-compose || true
 
 LABEL 'name'='Docker Deployment Action'
 LABEL 'com.github.actions.name'='Docker Deployment'
@@ -6,8 +12,7 @@ LABEL 'com.github.actions.description'='supports docker-compose and Docker Swarm
 LABEL 'com.github.actions.icon'='send'
 LABEL 'com.github.actions.color'='green'
 
-RUN apk --no-cache add openssh-client 
-
 COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Docker Remote Deployment Action
+
+A [GitHub Action](https://github.com/marketplace/actions/docker-remote-deployment) that supports docker-compose and Docker Swarm deployments on a remote host using SSH.
+
+The Action is adapted from work by [wshihadeh](https://github.com/wshihadeh/docker-deployment-action) and [TapTap21/docker-remote-deployment-action)
+
+## Example
+
+Below is a brief example on how the action can be used:
+
+```yaml
+- name: Deploy to Docker swarm
+  uses: sulthonzh/docker-remote-deployment-action@v1
+  with:
+    remote_docker_host: user@host
+    ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+    ssh_public_key: ${{ secrets.SSH_PUBLIC_KEY }}
+    deployment_mode: docker-swarm
+    copy_stack_file: true
+    deploy_path: /root/my-deployment
+    stack_file_name: docker-compose.yaml
+    keep_files: 5
+    args: my_applicaion
+```
+
+## Input Configurations
+### `remote_docker_host`
+  Remote Docker host ie (user@host).
+### `remote_docker_port`
+  Remote Docker ssh port ie (22).
+### `ssh_public_key`
+  Remote Docker SSH public key eg (~/.ssh/rsa_id.pub).
+### `ssh_private_key`
+  SSH private key used to connect to the docker host eg (~/.ssh/rsa_id).
+### `args`
+  Deployment command args.
+### `deployment_mode`
+  Deployment mode either docker-swarm or docker-compose. Default is docker-compose.
+### `copy_stack_file`
+  Copy stack file to remote server and deploy from the server. Default is false.
+### `deploy_path`
+  The path where the stack files will be copied to. Default ~/docker-deployment.
+### `stack_file_name`
+  Docker stack file used. Default is docker-compose.yml.
+### `keep_files`
+  Number of the files to be kept on the server. Default is 3.
+### `docker_prune`
+  A boolean input to trigger docker prune command. Default is false.
+### `pre_deployment_command_args`
+  The args for the pre deploument command.
+### `pull_images_first`
+  Pull docker images before deploying. Default is false.
+### `docker_registry_username`
+  The docker registry username.
+### `docker_registry_password`
+  The docker registry password.
+### `docker_registry_uri`
+  The docker registry URI. Default is https://registry.hub.docker.com.
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [GitHub Action](https://github.com/marketplace/actions/docker-remote-deployment) that supports docker-compose and Docker Swarm deployments on a remote host using SSH.
 
-The Action is adapted from work by [wshihadeh](https://github.com/wshihadeh/docker-deployment-action) and [TapTap21/docker-remote-deployment-action)
+The Action is adapted from work by [wshihadeh](https://github.com/wshihadeh/docker-deployment-action) and [TapTap21](https://github.com/TapTap21/docker-remote-deployment-action)
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Docker Deployment
+name: Docker Remote Deployment
 description: A GitHub Action that supports docker-compose and Docker Swarm deployments
 inputs:
   remote_docker_host:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -134,7 +134,6 @@ if ! [ -z "${INPUT_COPY_STACK_FILE+x}" ] && [ $INPUT_COPY_STACK_FILE = 'true' ] 
 
   execute_ssh ${DEPLOYMENT_COMMAND} "$INPUT_ARGS" 2>&1
 else
-  cat ~/.docker/config.json
   echo "Connecting to $INPUT_REMOTE_DOCKER_HOST... Command: ${DEPLOYMENT_COMMAND} ${INPUT_ARGS}"
   ${DEPLOYMENT_COMMAND} ${INPUT_ARGS} 2>&1
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -89,7 +89,7 @@ printf '%s\n' "$INPUT_SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa
 printf '%s\n' "$INPUT_SSH_PUBLIC_KEY" > ~/.ssh/id_rsa.pub
 chmod 600 ~/.ssh/id_rsa.pub
-#chmod 600 "~/.ssh"
+chmod 600 ~/.ssh
 eval $(ssh-agent)
 ssh-add ~/.ssh/id_rsa
 
@@ -97,7 +97,7 @@ echo "Add known hosts"
 ssh-keyscan -p $INPUT_REMOTE_DOCKER_PORT "$SSH_HOST" >> ~/.ssh/known_hosts
 ssh-keyscan -p $INPUT_REMOTE_DOCKER_PORT "$SSH_HOST" >> /etc/ssh/ssh_known_hosts
 
-set context
+# set context  # This command was causing issues and is commented out
 echo "Create docker context"
 docker context create remote --docker "host=ssh://$INPUT_REMOTE_DOCKER_HOST:$INPUT_REMOTE_DOCKER_PORT"
 docker context use remote
@@ -125,17 +125,17 @@ if ! [ -z "${INPUT_COPY_STACK_FILE+x}" ] && [ $INPUT_COPY_STACK_FILE = 'true' ] 
   execute_ssh "ls -t $INPUT_DEPLOY_PATH/stacks/docker-stack-* 2>/dev/null |  tail -n +$INPUT_KEEP_FILES | xargs rm --  2>/dev/null || true"
 
   if ! [ -z "${INPUT_PULL_IMAGES_FIRST+x}" ] && [ $INPUT_PULL_IMAGES_FIRST = 'true' ] && [ $INPUT_DEPLOYMENT_MODE = 'docker-compose' ] ; then
-    execute_ssh ${DEPLOYMENT_COMMAND} "pull"
+    execute_ssh "${DEPLOYMENT_COMMAND}" "pull"
   fi
 
   if ! [ -z "${INPUT_PRE_DEPLOYMENT_COMMAND_ARGS+x}" ] && [ $INPUT_DEPLOYMENT_MODE = 'docker-compose' ] ; then
     execute_ssh "${DEPLOYMENT_COMMAND}  $INPUT_PRE_DEPLOYMENT_COMMAND_ARGS" 2>&1
   fi
 
-  execute_ssh ${DEPLOYMENT_COMMAND} "$INPUT_ARGS" 2>&1
+  execute_ssh "${DEPLOYMENT_COMMAND}" "$INPUT_ARGS" 2>&1
 else
   echo "Connecting to $INPUT_REMOTE_DOCKER_HOST... Command: ${DEPLOYMENT_COMMAND} ${INPUT_ARGS}"
-  ${DEPLOYMENT_COMMAND} ${INPUT_ARGS} 2>&1
+  "${DEPLOYMENT_COMMAND}" "${INPUT_ARGS}" 2>&1
 fi
 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
-set -eu
+set -euo pipefail
 
 execute_ssh(){
-  echo "Execute Over SSH: $@"
-  ssh -q -t -i "$HOME/.ssh/id_rsa" \
+  echo "Execute Over SSH: $*"
+  ssh -q -i "$HOME/.ssh/id_rsa" \
       -o UserKnownHostsFile=/dev/null \
-      -p $INPUT_REMOTE_DOCKER_PORT \
-      -o StrictHostKeyChecking=no "$INPUT_REMOTE_DOCKER_HOST" "$@"
+      -p "$INPUT_REMOTE_DOCKER_PORT" \
+      -o StrictHostKeyChecking=no "$INPUT_REMOTE_DOCKER_HOST" "$*"
 }
 
 if [ -z "${INPUT_REMOTE_DOCKER_PORT+x}" ]; then
@@ -89,15 +89,16 @@ printf '%s\n' "$INPUT_SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa
 printf '%s\n' "$INPUT_SSH_PUBLIC_KEY" > ~/.ssh/id_rsa.pub
 chmod 600 ~/.ssh/id_rsa.pub
-chmod 600 ~/.ssh
+chmod 700 ~/.ssh
 eval $(ssh-agent)
 ssh-add ~/.ssh/id_rsa
 
 echo "Add known hosts"
-ssh-keyscan -p $INPUT_REMOTE_DOCKER_PORT "$SSH_HOST" >> ~/.ssh/known_hosts
-ssh-keyscan -p $INPUT_REMOTE_DOCKER_PORT "$SSH_HOST" >> /etc/ssh/ssh_known_hosts
+if ! ssh-keyscan -p "$INPUT_REMOTE_DOCKER_PORT" "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null; then
+  echo "Warning: ssh-keyscan failed for $SSH_HOST:$INPUT_REMOTE_DOCKER_PORT"
+fi
+ssh-keyscan -p "$INPUT_REMOTE_DOCKER_PORT" "$SSH_HOST" >> /etc/ssh/ssh_known_hosts 2>/dev/null || true
 
-# set context  # This command was causing issues and is commented out
 echo "Create docker context"
 docker context create remote --docker "host=ssh://$INPUT_REMOTE_DOCKER_HOST:$INPUT_REMOTE_DOCKER_PORT"
 docker context use remote
@@ -107,29 +108,36 @@ if ! [ -z "${INPUT_DOCKER_REGISTRY_USERNAME+x}" ] && ! [ -z "${INPUT_DOCKER_REGI
   echo "$INPUT_DOCKER_REGISTRY_PASSWORD" | docker login -u "$INPUT_DOCKER_REGISTRY_USERNAME" --password-stdin "$INPUT_DOCKER_REGISTRY_URI"
 fi
 
-if ! [ -z "${INPUT_DOCKER_PRUNE+x}" ] && [ $INPUT_DOCKER_PRUNE = 'true' ] ; then
+if ! [ -z "${INPUT_DOCKER_PRUNE+x}" ] && [ "$INPUT_DOCKER_PRUNE" = 'true' ] ; then
   yes | docker --log-level debug --host "ssh://$INPUT_REMOTE_DOCKER_HOST:$INPUT_REMOTE_DOCKER_PORT" system prune -a 2>&1
 fi
 
-if ! [ -z "${INPUT_COPY_STACK_FILE+x}" ] && [ $INPUT_COPY_STACK_FILE = 'true' ] ; then
+if ! [ -z "${INPUT_COPY_STACK_FILE+x}" ] && [ "$INPUT_COPY_STACK_FILE" = 'true' ] ; then
   execute_ssh "mkdir -p $INPUT_DEPLOY_PATH/stacks || true"
-  FILE_NAME="docker-stack-$(date +%Y%m%d%s).yaml"
+  FILE_NAME="docker-stack-$(date +%Y%m%d%H%M%S).yaml"
+
+  # Validate local stack file exists before copying
+  if [ ! -f "$INPUT_STACK_FILE_NAME" ]; then
+    echo "Error: Stack file '$INPUT_STACK_FILE_NAME' not found"
+    exit 1
+  fi
 
   scp -i "$HOME/.ssh/id_rsa" \
       -o UserKnownHostsFile=/dev/null \
       -o StrictHostKeyChecking=no \
-      -P $INPUT_REMOTE_DOCKER_PORT \
-      $INPUT_STACK_FILE_NAME "$INPUT_REMOTE_DOCKER_HOST:$INPUT_DEPLOY_PATH/stacks/$FILE_NAME"
+      -P "$INPUT_REMOTE_DOCKER_PORT" \
+      "$INPUT_STACK_FILE_NAME" "$INPUT_REMOTE_DOCKER_HOST:$INPUT_DEPLOY_PATH/stacks/$FILE_NAME"
 
   execute_ssh "ln -nfs $INPUT_DEPLOY_PATH/stacks/$FILE_NAME $INPUT_DEPLOY_PATH/$INPUT_STACK_FILE_NAME"
-  execute_ssh "ls -t $INPUT_DEPLOY_PATH/stacks/docker-stack-* 2>/dev/null |  tail -n +$INPUT_KEEP_FILES | xargs rm --  2>/dev/null || true"
+  # Use find + sort for safe cleanup (handles filenames with spaces)
+  execute_ssh "find '$INPUT_DEPLOY_PATH/stacks' -name 'docker-stack-*.yaml' -print0 2>/dev/null | sort -zr | tail -zn +$INPUT_KEEP_FILES | xargs -0 rm -- 2>/dev/null || true"
 
-  if ! [ -z "${INPUT_PULL_IMAGES_FIRST+x}" ] && [ $INPUT_PULL_IMAGES_FIRST = 'true' ] && [ $INPUT_DEPLOYMENT_MODE = 'docker-compose' ] ; then
+  if ! [ -z "${INPUT_PULL_IMAGES_FIRST+x}" ] && [ "$INPUT_PULL_IMAGES_FIRST" = 'true' ] && [ "$INPUT_DEPLOYMENT_MODE" = 'docker-compose' ] ; then
     execute_ssh "${DEPLOYMENT_COMMAND}" "pull"
   fi
 
-  if ! [ -z "${INPUT_PRE_DEPLOYMENT_COMMAND_ARGS+x}" ] && [ $INPUT_DEPLOYMENT_MODE = 'docker-compose' ] ; then
-    execute_ssh "${DEPLOYMENT_COMMAND}  $INPUT_PRE_DEPLOYMENT_COMMAND_ARGS" 2>&1
+  if ! [ -z "${INPUT_PRE_DEPLOYMENT_COMMAND_ARGS+x}" ] && [ -n "$INPUT_PRE_DEPLOYMENT_COMMAND_ARGS" ] && [ "$INPUT_DEPLOYMENT_MODE" = 'docker-compose' ] ; then
+    execute_ssh "${DEPLOYMENT_COMMAND} $INPUT_PRE_DEPLOYMENT_COMMAND_ARGS" 2>&1
   fi
 
   execute_ssh "${DEPLOYMENT_COMMAND}" "$INPUT_ARGS" 2>&1
@@ -137,5 +145,3 @@ else
   echo "Connecting to $INPUT_REMOTE_DOCKER_HOST... Command: ${DEPLOYMENT_COMMAND} ${INPUT_ARGS}"
   "${DEPLOYMENT_COMMAND}" "${INPUT_ARGS}" 2>&1
 fi
-
-

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:base"
+  ]
+}


### PR DESCRIPTION
## Changes

### Dockerfile
- **Upgrade docker/compose 1.29.2 → 2.24.5** — the old image has been EOL for years with known CVEs. Also adds docker-compose v2 CLI plugin symlink.

### docker-entrypoint.sh
- **Remove `-t` from execute_ssh** — forces TTY allocation which fails in non-interactive CI runners (GitHub Actions containers don't have a TTY)
- **Add `pipefail`** — without it, pipe failures are silently swallowed by `set -eu` alone
- **Fix `chmod 600 ~/.ssh` → `chmod 700`** — directories need execute permission to be traversable; 600 breaks `cd ~/.ssh` on some systems
- **Fix timestamp format `%Y%m%d%s` → `%Y%m%d%H%M%S`** — `%s` is epoch seconds, producing inconsistent filenames vs the documented pattern
- **Quote all unquoted variable expansions** in ssh/scp port arguments
- **Replace `ls -t | tail | xargs` cleanup with `find | sort -zr | tail -zn | xargs -0`** — handles filenames with spaces correctly
- **Add stack file existence check** before scp — fails early with clear error instead of cryptic scp failure
- **Skip pre-deploy args when empty** — added `-n` check to avoid sending empty string as command
- **Warn on ssh-keyscan failure** instead of silently succeeding with no known hosts