### PR TITLE
fix: critical bugs — shell hang, CI hang, broken validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL 'com.github.actions.icon'='send'
 LABEL 'com.github.actions.color'='green'
 
 # Install SSH client, curl and Docker Compose
-RUN apk --no-cache add openssh-client curl \
+RUN apk --no-cache add openssh-client curl bash \
     && curl -L "https://github.com/docker/compose/releases/download/v2.29.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 # Cleanup function to remove SSH keys and agent
@@ -7,7 +7,7 @@ cleanup() {
   # Remove SSH keys
   rm -f ~/.ssh/id_rsa ~/.ssh/id_rsa.pub 2>/dev/null || true
   # Kill SSH agent if running
-  if [ -n "$SSH_AGENT_PID" ]; then
+  if [ -n "${SSH_AGENT_PID:-}" ]; then
     kill $SSH_AGENT_PID 2>/dev/null || true
   fi
   # Remove docker context
@@ -64,40 +64,40 @@ fi
 validate_input() {
   local input_name="$1"
   local input_value="$2"
-  
+
   # Check for shell metacharacters that could cause command injection
-  if echo "$input_value" | grep -qE '[;&|`\$()\"\'\'']; then
-    echo "Error: $input_name contains dangerous characters: $input_value"
+  if printf '%s' "$input_value" | grep -qE '[;&|`$()"'"'"']'; then
+    echo "Error: $input_name contains dangerous characters"
     exit 1
   fi
-  
-  # Check for path traversal attempts
-  if echo "$input_value" | grep -qE '\\.\.'; then
-    echo "Error: $input_name contains path traversal attempts: $input_value"
-    exit 1
-  fi
+
+  # Check for path traversal attempts (..)
+  case "$input_value" in
+    *..*) echo "Error: $input_name contains path traversal attempts"; exit 1 ;;
+  esac
 }
 
 validate_input "args" "$INPUT_ARGS"
 validate_input "deploy_path" "$INPUT_DEPLOY_PATH"
 validate_input "stack_file_name" "$INPUT_STACK_FILE_NAME"
 
+# Set default for KEEP_FILES before validating
+if [ -z "${INPUT_KEEP_FILES+x}" ]; then
+  INPUT_KEEP_FILES=4
+fi
+
 # Ensure numeric inputs are valid numbers
-if [[ ! "$INPUT_REMOTE_DOCKER_PORT" =~ ^[0-9]+$ ]]; then
+if ! [[ "$INPUT_REMOTE_DOCKER_PORT" =~ ^[0-9]+$ ]]; then
   echo "Error: remote_docker_port must be a number: $INPUT_REMOTE_DOCKER_PORT"
   exit 1
 fi
 
-if [[ ! "$INPUT_KEEP_FILES" =~ ^[0-9]+$ ]]; then
+if ! [[ "$INPUT_KEEP_FILES" =~ ^[0-9]+$ ]]; then
   echo "Error: keep_files must be a number: $INPUT_KEEP_FILES"
   exit 1
 fi
 
-if [ -z "${INPUT_KEEP_FILES+x}" ]; then
-  INPUT_KEEP_FILES=4
-else
-  INPUT_KEEP_FILES=$((INPUT_KEEP_FILES+1))
-fi
+INPUT_KEEP_FILES=$((INPUT_KEEP_FILES+1))
 
 if [ -z "${INPUT_DOCKER_REGISTRY_URI+x}" ]; then
   INPUT_DOCKER_REGISTRY_URI=https://registry.hub.docker.com
@@ -184,7 +184,7 @@ if ! [ -z "${INPUT_DOCKER_PRUNE+x}" ] && [ "$INPUT_DOCKER_PRUNE" = 'true' ] ; th
   echo "WARNING: This will remove unused images, containers, networks, and volumes."
   echo "This is a destructive operation that cannot be undone."
   echo "Proceeding with docker prune automatically..."
-  if ! docker --log-level debug --host "ssh://$INPUT_REMOTE_DOCKER_HOST:$INPUT_REMOTE_DOCKER_PORT" system prune -a; then
+  if ! docker --log-level debug --host "ssh://$INPUT_REMOTE_DOCKER_HOST:$INPUT_REMOTE_DOCKER_PORT" system prune -a -f; then
     echo "Error: Docker prune failed"
     exit 1
   fi


### PR DESCRIPTION
## What's broken

### 1. `#!/bin/sh` with bash-only syntax (CRITICAL)
The script uses `[[ =~ ]]` regex matching and `set -o pipefail`, both bash-only features. On the `docker:26.1.0` base image (Alpine/busybox ash), these cause immediate syntax errors and the script never runs.

**Fix:** Changed shebang to `#!/bin/bash` and added `bash` to the Dockerfile.

### 2. `docker system prune -a` hangs CI (CRITICAL)
`docker system prune -a` without `-f` prompts for `[y/N]` confirmation. In non-interactive CI, this hangs forever and the job times out.

**Fix:** Added `-f` flag.

### 3. Path traversal regex was broken
`grep -qE '\\.\.'` matches backslash + any-char + literal-dot — not `..`. Path traversal detection was completely non-functional.

**Fix:** Replaced with a POSIX `case` statement (`*..*`).

### 4. Shell metacharacter regex had broken quoting
The single-quote escaping inside the grep pattern was malformed, producing a pattern that didn't match what was intended.

**Fix:** Rewrote with correct quote concatenation.

### 5. INPUT_KEEP_FILES validated before default assignment
With `set -u` active, the regex check on `` would crash the script if the variable wasn't set — before the code that assigns the default value of 4.

**Fix:** Moved default assignment before the validation.